### PR TITLE
Fix pedantic clippy lints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 keywords = ["jwt", "nats", "nkey", "nkeys"]
 categories = ["api-bindings", "authentication"]
 repository = "https://github.com/AircastDev/nats-jwt"
+rust-version = "1.58"
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -440,11 +440,11 @@ impl<T: IntoNatsClaims> Token<T> {
 
         let b64_header = BASE64URL_NOPAD.encode(JWT_HEADER.as_bytes());
         let b64_body = BASE64URL_NOPAD.encode(claims_str.as_bytes());
-        let jwt_half = format!("{}.{}", b64_header, b64_body);
+        let jwt_half = format!("{b64_header}.{b64_body}");
         let sig = signing_key.sign(jwt_half.as_bytes()).unwrap();
         let b64_sig = BASE64URL_NOPAD.encode(&sig);
 
-        format!("{}.{}", jwt_half, b64_sig)
+        format!("{jwt_half}.{b64_sig}")
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -153,6 +153,7 @@ pub struct NatsPermissions {
 
 impl NatsPermissions {
     /// Returns `true` if the allow and deny list are both empty
+    #[must_use]
     pub fn is_empty(&self) -> bool {
         self.allow.is_empty() && self.deny.is_empty()
     }
@@ -341,54 +342,63 @@ impl<T: IntoNatsClaims> Token<T> {
     }
 
     /// Set the friendly name for the token, can be anything, defaults to the token subject
+    #[must_use]
     pub fn name(mut self, name: impl Into<String>) -> Self {
         self.name = Some(name.into());
         self
     }
 
     /// Set the maximum number of subscriptions this token will allow
+    #[must_use]
     pub fn max_subscriptions(mut self, max_subscriptions: i64) -> Self {
         self.nats.max_subscriptions = max_subscriptions;
         self
     }
 
     /// Set the maximum payload size in bytes this token will allow
+    #[must_use]
     pub fn max_payload(mut self, max_payload: i64) -> Self {
         self.nats.max_payload = max_payload;
         self
     }
 
     /// Set the maximum data size in bytes this token will allow
+    #[must_use]
     pub fn max_data(mut self, max_data: i64) -> Self {
         self.nats.max_data = max_data;
         self
     }
 
     /// Allow a subject/pattern to be published to
+    #[must_use]
     pub fn allow_publish(mut self, subject: impl Into<String>) -> Self {
         self.nats.permissions.publish.allow.push(subject.into());
         self
     }
 
     /// Deny a subject/pattern from being published to
+    #[must_use]
     pub fn deny_publish(mut self, subject: impl Into<String>) -> Self {
         self.nats.permissions.publish.deny.push(subject.into());
         self
     }
 
     /// Allow a subject/pattern to be subcribe to
+    #[must_use]
     pub fn allow_subscribe(mut self, subject: impl Into<String>) -> Self {
         self.nats.permissions.subscribe.allow.push(subject.into());
         self
     }
 
     /// Deny a subject/pattern from being subscribed to
+    #[must_use]
     pub fn deny_subscribe(mut self, subject: impl Into<String>) -> Self {
         self.nats.permissions.subscribe.deny.push(subject.into());
         self
     }
 
     /// Set expiration
+    #[must_use]
     pub fn expires(mut self, expires: i64) -> Self {
         self.expires = Some(expires);
         self
@@ -450,6 +460,7 @@ impl Token<User> {
 
     /// If true, the user isn't challenged on connection. Typically used for websocket
     /// connections as the browser won't have/want to have the user's private key.
+    #[must_use]
     pub fn bearer_token(mut self, bearer_token: bool) -> Self {
         self.kind.bearer_token = bearer_token;
         self
@@ -476,36 +487,42 @@ impl Token<Account> {
 
     /// Add a signing key to the token. Takes anything that implements IntoPublicKey. This is
     /// implemented for `String`, `&str`, and [`&KeyPair`](nkeys::KeyPair)
+    #[must_use]
     pub fn add_signing_key(mut self, signing_key: impl IntoPublicKey) -> Self {
         self.kind.signing_keys.push(signing_key.into_public_key());
         self
     }
 
     /// Set the maximum number of imports this account can have.
+    #[must_use]
     pub fn max_imports(mut self, max_imports: i64) -> Self {
         self.kind.max_imports = max_imports;
         self
     }
 
     /// Set the maximum number of exports this account can have.
+    #[must_use]
     pub fn max_exports(mut self, max_exports: i64) -> Self {
         self.kind.max_exports = max_exports;
         self
     }
 
     /// Set the maximum number of connections this account can have.
+    #[must_use]
     pub fn max_connections(mut self, max_connections: i64) -> Self {
         self.kind.max_connections = max_connections;
         self
     }
 
     /// Set the maximum number of leaf nodes this account can have.
+    #[must_use]
     pub fn max_leaf_nodes(mut self, max_leaf_nodes: i64) -> Self {
         self.kind.max_leaf_nodes = max_leaf_nodes;
         self
     }
 
     /// Allow exports to contain wildcards
+    #[must_use]
     pub fn allow_wildcards(mut self, allow_wildcards: bool) -> Self {
         self.kind.allow_wildcards = allow_wildcards;
         self

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,9 +40,9 @@
 //! Licensed under either of
 //!
 //! -   Apache License, Version 2.0
-//!     ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
+//!     ([LICENSE-APACHE](LICENSE-APACHE) or <http://www.apache.org/licenses/LICENSE-2.0>)
 //! -   MIT license
-//!     ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+//!     ([LICENSE-MIT](LICENSE-MIT) or <http://opensource.org/licenses/MIT>)
 //!
 //! at your option.
 //!
@@ -57,7 +57,7 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::time::SystemTime;
 
-/// Re-export of KeyPair from the nkeys crate.
+/// Re-export of `KeyPair` from the nkeys crate.
 ///
 pub use nkeys::KeyPair;
 
@@ -212,7 +212,7 @@ pub struct CommonNatsClaims {
     pub permissions: NatsPermissionsMap,
 }
 
-/// Consume the input and return a NatsClaims struct
+/// Consume the input and return a `NatsClaims` struct
 ///
 /// This is used by [`Token::sign`] to get the relevant claims for the token type
 pub trait IntoNatsClaims {
@@ -222,7 +222,7 @@ pub trait IntoNatsClaims {
 
 /// Consume the input and return a public KKEY
 ///
-/// This is used by [`Token::add_signing_key`] to allow taking either a String, &str, or a &KeyPair
+/// This is used by [`Token::add_signing_key`] to allow taking either a String, &str, or a &`KeyPair`
 pub trait IntoPublicKey {
     /// Performs the conversion
     fn into_public_key(self) -> String;
@@ -408,6 +408,10 @@ impl<T: IntoNatsClaims> Token<T> {
     ///
     /// If this is a User token, this should be the Account signing key.
     /// If this is an Account token, this should be the Operator key
+    ///
+    /// # Panics
+    ///
+    /// It panics if system time is before UNIX epoch.
     pub fn sign(self, signing_key: &KeyPair) -> String {
         let issued_at = SystemTime::now()
             .duration_since(SystemTime::UNIX_EPOCH)
@@ -485,7 +489,7 @@ impl Token<Account> {
         )
     }
 
-    /// Add a signing key to the token. Takes anything that implements IntoPublicKey. This is
+    /// Add a signing key to the token. Takes anything that implements `IntoPublicKey`. This is
     /// implemented for `String`, `&str`, and [`&KeyPair`](nkeys::KeyPair)
     #[must_use]
     pub fn add_signing_key(mut self, signing_key: impl IntoPublicKey) -> Self {


### PR DESCRIPTION
I just run clippy in _pedantic mode_ and fixed the related minor issue.

There are two points that could be argument of discussion:
- I used the _inlined_ form of named format arguments, which requires a MSRV bump to 1.58. At this point I do not think it should be an issue because it is a version from some time ago. Nevertheless, it does not require a major version bump.
- I removed an implicit wrap around conversion from `u64` to `i64`, and I transformed it into a panic. This should be considered a breaking change on its own, but in practice the value is the seconds of `SystemTime::now()` from the `UNIX_EPOCH`. Thus, it should only involve systems maliciously set in the future, and I really thing it can be considered a non-breaking change.

Let me know, and thank you in advance.